### PR TITLE
add support for transport = beacon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,18 @@
 {
   "name": "Roger-Watcher",
   "description": "A validator for Universal Analytics implementations",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "author": "dp6",
   "homepage": "http://www.digitalcube.com.br/",
   "repository": {
     "type": "git",
     "url": "https://github.com/digitalinc/roger-watcher.git"
   },
+  "contributors": [
+    {
+      "name": "Paychex, Inc."
+    }
+  ],
   "bugs": {
     "url": "https://github.com/digitalinc/roger-watcher/issues"
   },

--- a/src/js/rules.js
+++ b/src/js/rules.js
@@ -1,6 +1,6 @@
 window.commonRules = {
 	regex: {
-		universal_analytics_url: /^https?:\/\/(www\.)?google-analytics.com\/collect\?/i,
+		universal_analytics_url: /^https?:\/\/(www\.)?google-analytics.com\/collect\??/i,
 		trackingID: /^UA\-\d+\-\d{1,2}$/
 	},
 	universal_analytics: function(url) {

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -37,9 +37,9 @@ var PUDIM = window.PUDIM = (function() {
 					clone.find('table.queryString').html(objectToRows(obj.parameters));
 					panel.append(clone);
 				},
-				handler: function (url) {
+				handler: function (url, content) {
 					var qs = url.slice(url.indexOf('?') + 1),
-						params = queryToObject(qs),
+						params = queryToObject(content || qs),
 						label = '',
 						status = 'ok',
 						errors;
@@ -165,9 +165,10 @@ var PUDIM = window.PUDIM = (function() {
 	}
 
 	function init(details) {
-		var url = details.request.url;
+		var url = details.request.url,
+			content = details.request.method === "POST" && details.request.postData.text;
 		if (commonRules.universal_analytics(url)) {
-			modules.universal_analytics.handler(url);
+			modules.universal_analytics.handler(url, content);
 			if (autoscroll) autoscroll();
 		}
 	}


### PR DESCRIPTION
Google Analytics supports an option to send collection data as a POST instead of a GET. See "Specifying different transport mechanisms" [here](https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits). Google mentions that using navigator.sendBeacon may become the default transport mode for GA in the future.