### PR TITLE
Invertida ordem da adição dos eventos no relatório

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -35,7 +35,7 @@ var PUDIM = window.PUDIM = (function() {
 					clone.find('.label').addClass(obj.status);
 					clone.find('.content').attr('title', obj.content).text(obj.content);
 					clone.find('table.queryString').html(objectToRows(obj.parameters));
-					panel.append(clone);
+					panel.prepend(clone);
 				},
 				handler: function (url, content) {
 					var qs = url.slice(url.indexOf('?') + 1),


### PR DESCRIPTION
Na configuração atual, novos eventos são adicionados no relatório como últimos na lista, usando o método JQuery append. Isto cria uma lista progressiva de data/hora onde, para ver os últimos eventos que estão sendo disparados, é necessários dar scroll na tela.

Ao trocar o append por prepend (http://api.jquery.com/prepend/), os eventos disparados por últimos (mais relevantes) passam a ser os primeiros da lista. Desta forma, é mais confortável utilizar a extensão utilizando uma fração menor da tela (por exemplo, na parte inferior).