### PR TITLE
Feature/support batch

### DIFF
--- a/src/js/rules.js
+++ b/src/js/rules.js
@@ -1,7 +1,7 @@
 window.commonRules = {
   regex: {
-    universal_analytics_url: /^https?:\/\/(www|ssl)\.google-analytics.com\/([a-z]\/)?collect\??/i,
-    analytics4_url: /^https?:\/\/analytics.google.com\/([a-z]\/)?collect\??/i,
+    universal_analytics_url: /^https?:\/\/(www|ssl)\.google-analytics.com\/([a-z]\/)?(collect|batch)\??/i,
+    analytics4_url: /^https?:\/\/analytics.google.com\/([a-z]\/)?(collect|batch)\??/i,
     trackingID: /^UA\-\d+\-\d{1,2}$/,
     hitType: /^(pageview|appview|event|transaction|item|social|exception|timing)$/
   },

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -219,7 +219,13 @@ const RW = (function () {
         })
         .map(row => row.split('\n'))
         .flat()
-        .forEach((row) => modules.universal_analytics.handler(url, row));
+        .forEach((row) => {
+          if (row.includes('v=2')) {
+            modules.analytics4.handler(url, row);
+          } else {
+            modules.universal_analytics.handler(url, row);
+          }
+        });
     }
   }
 

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -217,6 +217,8 @@ const RW = (function () {
         .map(function (data) {
           return String.fromCharCode(...new Uint8Array(data.bytes));
         })
+        .map(row => row.split('\n'))
+        .flat()
         .forEach((row) => modules.universal_analytics.handler(url, row));
     }
   }
@@ -245,6 +247,10 @@ chrome.webRequest.onBeforeRequest.addListener(
       '*://*.google-analytics.com/*/collect*',
       '*://*.analytics.google.com/*/collect*',
       '*://*.analytics.google.com/collect*',
+      '*://*.google-analytics.com/batch*',
+      '*://*.google-analytics.com/*/batch*',
+      '*://*.analytics.google.com/*/batch*',
+      '*://*.analytics.google.com/batch*',
     ],
   },
   ['requestBody']


### PR DESCRIPTION
## Overview
This PR adds support for the `/batch` series of endpoints.

Fixes #16 

## Description
This PR updates the URL rules to include `/batch` endpoints and updates the `init` method to split the request body on newline characters and treat each separate line as a separate event.  This allows it to properly recognize batched analytics requests.  I have done some basic testing on a site that uses the `/batch` API and I am seeing the events get logged now.